### PR TITLE
A new context menu with reordering functionality

### DIFF
--- a/src/Goat/Helpers.elm
+++ b/src/Goat/Helpers.elm
@@ -343,3 +343,8 @@ selectSpotlight shapeType keyboardState =
             DrawingEqualizedShape
         else
             DrawingShape
+
+
+defaultPrevented : Html.Events.Options
+defaultPrevented =
+    Html.Events.Options False True

--- a/src/Goat/Model.elm
+++ b/src/Goat/Model.elm
@@ -228,6 +228,8 @@ type alias Model =
     , currentDropdown : Maybe AttributeDropdown
     , drawing : Drawing
     , operatingSystem : OperatingSystem
+    , annotationMenu : Maybe { index : Int, position : Position }
+    , showingAnyMenu : Bool
     }
 
 
@@ -329,6 +331,8 @@ init flags =
             MacOS
         else
             Windows
+    , annotationMenu = Nothing
+    , showingAnyMenu = False
     }
 
 

--- a/src/Goat/Update.elm
+++ b/src/Goat/Update.elm
@@ -46,6 +46,8 @@ type Msg
     | StartResizingAnnotation Int Vertex StartPosition
     | ResizeAnnotation Position
     | FinishResizingAnnotation Position
+      -- Annotation menu updates
+    | BringAnnotationToFront Int
       -- History updates
     | Undo
     | Redo
@@ -56,7 +58,7 @@ type Msg
     | Cancel
       -- Keyboard updates
     | KeyboardMsg Keyboard.Msg
-      -- Fun
+      -- !!! GOATS !!!
     | ShowMeTheGoats
 
 
@@ -233,6 +235,10 @@ update msg ({ edits, fill, fontSize, strokeColor, strokeStyle, mouse, images, ke
             model
                 |> resizeAnnotation pos
                 |> finishResizingAnnotation
+                => []
+
+        BringAnnotationToFront index ->
+            model
                 => []
 
         Undo ->

--- a/src/Goat/Update.elm
+++ b/src/Goat/Update.elm
@@ -49,6 +49,7 @@ type Msg
       -- Annotation menu updates
     | ToggleAnnotationMenu Int Position
     | BringAnnotationToFront Int
+    | SendAnnotationToBack Int
       -- History updates
     | Undo
     | Redo
@@ -248,6 +249,11 @@ update msg ({ edits, fill, fontSize, strokeColor, strokeStyle, mouse, images, ke
         BringAnnotationToFront index ->
             model
                 |> bringAnnotationToFront index
+                => []
+
+        SendAnnotationToBack index ->
+            model
+                |> sendAnnotationToBack index
                 => []
 
         ToggleAnnotationMenu index pos ->
@@ -958,6 +964,22 @@ bringAnnotationToFront index model =
     { model
         | edits = UndoList.new (bringToFront index model.edits.present) model.edits
     }
+        |> closeAllMenus
+
+
+sendToBack : Int -> Array Annotation -> Array Annotation
+sendToBack index annotations =
+    case Array.get index annotations of
+        Just annotation ->
+            Array.append (Array.fromList [ annotation ]) (Array.append (Array.slice 0 index annotations) (Array.slice (index + 1) (Array.length annotations) annotations))
+
+        Nothing ->
+            annotations
+
+
+sendAnnotationToBack : Int -> Model -> Model
+sendAnnotationToBack index model =
+    { model | edits = UndoList.new (sendToBack index model.edits.present) model.edits }
         |> closeAllMenus
 
 

--- a/src/Goat/View.elm
+++ b/src/Goat/View.elm
@@ -1049,7 +1049,6 @@ viewAnnotationMenu : Position -> Int -> Html Msg
 viewAnnotationMenu pos index =
     div
         [ id "annotation-menu"
-          -- , onWithOptions "contextmenu" defaultPrevented
         , class "annotation-menu"
         , Html.style
             [ ( "top", toPx pos.y )
@@ -1058,6 +1057,7 @@ viewAnnotationMenu pos index =
         ]
         [ Html.ul [ class "annotation-menu__list" ]
             [ viewAnnotationMenuItem (BringAnnotationToFront index) "Bring to Front"
+            , viewAnnotationMenuItem (SendAnnotationToBack index) "Send to Back"
             ]
         ]
 

--- a/src/Goat/View.elm
+++ b/src/Goat/View.elm
@@ -84,7 +84,10 @@ viewImageAnnotator ({ edits, fill, strokeColor, strokeStyle, mouse, keyboardStat
     in
         div
             [ Html.class "annotation-app" ]
-            [ div [ Html.class "controls" ]
+            [ viewModals model
+            , viewModalMask model.showingAnyMenu
+            , div
+                [ Html.class "controls" ]
                 [ div [ Html.class "columns" ]
                     [ button [ onClick Cancel, Html.class "cancel-button" ] [ Html.text "Cancel" ]
                     , button [ onClick Save, Html.class "save-button" ] [ Html.text "Save" ]
@@ -100,6 +103,25 @@ viewImageAnnotator ({ edits, fill, strokeColor, strokeStyle, mouse, keyboardStat
                 ]
             , viewDrawingArea model selectedImage
             ]
+
+
+viewModals : Model -> Html Msg
+viewModals model =
+    case model.annotationMenu of
+        Just { index, position } ->
+            viewAnnotationMenu position index
+
+        Nothing ->
+            Html.text ""
+
+
+viewModalMask : Bool -> Html Msg
+viewModalMask showingAnyMenu =
+    div
+        [ classList [ ( "modal-mask", True ), ( "hidden", not showingAnyMenu ) ]
+        , onClick CloseAllMenus
+        ]
+        []
 
 
 viewVanillaDrawingButton : Keyboard.State -> Drawing -> Drawing -> Html Msg
@@ -368,6 +390,7 @@ drawingStateEvents drawing annotationState =
             [ onMouseDown <| Json.map (StartDrawing << toDrawingPosition) Mouse.position
             , ST.onSingleTouch T.TouchStart T.preventAndStop <| (StartDrawing << toDrawingPosition << toPosition)
             , Html.contextmenu "annotation-menu"
+            , onWithOptions "contextmenu" defaultPrevented (Json.map (ToggleAnnotationMenu index) Mouse.position)
             ]
 
         EditingATextBox index ->
@@ -395,7 +418,7 @@ viewSpotlights annotationState annotations =
         |> Array.filter isSpotlightShape
         |> Array.map spotlightFillToMaskFill
         |> Array.toList
-        |> List.indexedMap (viewAnnotation annotationState)
+        |> List.indexedMap (viewMaskAnnotation annotationState)
         |> List.concat
 
 
@@ -623,6 +646,16 @@ getSelectState index annotationState =
 
         _ ->
             NotSelected
+
+
+viewMaskAnnotation : AnnotationState -> Int -> Annotation -> List (Svg Msg)
+viewMaskAnnotation annotationState index annotation =
+    case annotation of
+        Spotlight shapeType shape ->
+            viewShape (annotationStateEvents index annotation annotationState) [] shapeType shape
+
+        _ ->
+            []
 
 
 viewAnnotation : AnnotationState -> Int -> Annotation -> List (Svg Msg)

--- a/src/Goat/View.elm
+++ b/src/Goat/View.elm
@@ -367,6 +367,7 @@ drawingStateEvents drawing annotationState =
         SelectedAnnotation index ->
             [ onMouseDown <| Json.map (StartDrawing << toDrawingPosition) Mouse.position
             , ST.onSingleTouch T.TouchStart T.preventAndStop <| (StartDrawing << toDrawingPosition << toPosition)
+            , Html.contextmenu "annotation-menu"
             ]
 
         EditingATextBox index ->
@@ -1009,3 +1010,31 @@ viewImage { width, height, url } =
         , src url
         ]
         []
+
+
+viewAnnotationMenu : Position -> Int -> Html Msg
+viewAnnotationMenu pos index =
+    div
+        [ id "annotation-menu"
+          -- , onWithOptions "contextmenu" defaultPrevented
+        , class "annotation-menu"
+        , Html.style
+            [ ( "top", toPx pos.y )
+            , ( "left", toPx pos.x )
+            ]
+        ]
+        [ Html.ul [ class "annotation-menu__list" ]
+            [ viewAnnotationMenuItem (BringAnnotationToFront index) "Bring to Front"
+            ]
+        ]
+
+
+viewAnnotationMenuItem : Msg -> String -> Html Msg
+viewAnnotationMenuItem msg buttonText =
+    Html.li [ class "annotation-menu__item" ]
+        [ button
+            [ Html.class "annotation-menu__button"
+            , onClick msg
+            ]
+            [ Html.text buttonText ]
+        ]

--- a/style.css
+++ b/style.css
@@ -272,7 +272,7 @@ button:active, button:focus, button:hover {
 
 .annotation-menu {
   position: fixed;
-  z-index: 1;
+  z-index: 4;
   background-color: white;
 }
 
@@ -310,4 +310,17 @@ button:active, button:focus, button:hover {
   text-align: left;
   padding: 5px;
   color: inherit;
+}
+
+.modal-mask {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 3;
+}
+
+.hidden {
+  visibility: hidden;
 }

--- a/style.css
+++ b/style.css
@@ -268,3 +268,46 @@ button:active, button:focus, button:hover {
   margin-left: 3px;
   height: 40px;
 }
+
+
+.annotation-menu {
+  position: fixed;
+  z-index: 1;
+  background-color: white;
+}
+
+.annotation-menu__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #DDDDDD;
+  border-radius: 5px;
+}
+
+.annotation-menu__item {
+  overflow: hidden;
+}
+
+.annotation-menu__item:hover {
+  background-color: rgb(230, 230, 230);
+  color: white;
+}
+
+.annotation-menu__item:first-child {
+  border-radius: 4px 4px 0 0;
+}
+
+.annotation-menu__item:last-child {
+  border-radius: 0 0 4px 4px;
+}
+
+.annotation-menu__button {
+  width: 100%;
+  border: 0px;
+  background-color: inherit;
+  text-align: left;
+  padding: 5px;
+  color: inherit;
+}

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -36,6 +36,8 @@ model =
     , drawing = DrawLine Arrow DrawingLine
     , annotationState = ReadyToDraw
     , operatingSystem = MacOS
+    , annotationMenu = Nothing
+    , showingAnyMenu = False
     }
 
 


### PR DESCRIPTION
Sloppy gif but it works 🎉 

![screen recording 2017-04-09 at 01 01 am](https://cloud.githubusercontent.com/assets/3099999/24835792/38c3db62-1cc0-11e7-9998-c6874efde68b.gif)

## And there was a gross bug

A nasty bug was found while building this. If the indexes matched up, the cut out shapes in the mask were getting vertices 😱! This happened because I was calling `viewAnnotation` for svg definitions too 😢 . Fixed it in this PR, but will either/both a) add a test to stop this from creeping up again, or make it impossible with better modeling. Will track in #46
