### PR TITLE
Change circle drawing to be corner-to-corner

### DIFF
--- a/src/Goat/Update.elm
+++ b/src/Goat/Update.elm
@@ -638,12 +638,7 @@ resize resizingData annotation =
             Lines lineType (resizeVertices resizingData shape)
 
         Shapes shapeType fill shape ->
-            case shapeType of
-                Ellipse ->
-                    Shapes shapeType fill (resizeVertices resizingData shape)
-
-                _ ->
-                    Shapes shapeType fill (resizeVertices resizingData shape)
+            Shapes shapeType fill (resizeVertices resizingData shape)
 
         TextBox textArea ->
             TextBox (resizeVertices resizingData textArea)

--- a/src/Goat/Update.elm
+++ b/src/Goat/Update.elm
@@ -631,32 +631,6 @@ resizeVertices { curPos, vertex, originalCoords } annotation =
                 { annotation | start = curPos, end = Position end.x start.y }
 
 
-resizeEllipseVertices : ResizingData -> { a | start : Position, end : Position } -> { a | start : Position, end : Position }
-resizeEllipseVertices { curPos, vertex, originalCoords } annotation =
-    let
-        ( start, end ) =
-            originalCoords
-
-        dX =
-            start.x - curPos.x
-
-        dY =
-            end.y - curPos.y
-    in
-        case vertex of
-            Start ->
-                { annotation | start = Position (curPos.x + ((end.x - curPos.x) // 2)) (end.y - (dY // 2)) }
-
-            Goat.Model.End ->
-                { annotation | end = curPos }
-
-            StartPlusX ->
-                { annotation | start = Position (curPos.x + ((end.x - curPos.x) // 2) - ((end.x - start.x) // 2)) (end.y - (dY // 2)), end = Position start.x end.y }
-
-            StartPlusY ->
-                { annotation | start = Position (curPos.x + ((end.x - curPos.x) // 2)) (start.y - ((start.y - curPos.y) // 2)), end = Position end.x start.y }
-
-
 resize : ResizingData -> Annotation -> Annotation
 resize resizingData annotation =
     case annotation of
@@ -666,7 +640,7 @@ resize resizingData annotation =
         Shapes shapeType fill shape ->
             case shapeType of
                 Ellipse ->
-                    Shapes shapeType fill (resizeEllipseVertices resizingData shape)
+                    Shapes shapeType fill (resizeVertices resizingData shape)
 
                 _ ->
                     Shapes shapeType fill (resizeVertices resizingData shape)

--- a/src/Goat/View.elm
+++ b/src/Goat/View.elm
@@ -834,10 +834,10 @@ rectAttrs { start, end } =
 
 ellipseAttributes : Shape -> List (Svg.Attribute Msg)
 ellipseAttributes { start, end } =
-    [ Attr.rx <| toString <| abs <| end.x - start.x
-    , Attr.ry <| toString <| abs <| end.y - start.y
-    , Attr.cx <| toString start.x
-    , Attr.cy <| toString start.y
+    [ Attr.rx <| toString <| abs <| (end.x - start.x) // 2
+    , Attr.ry <| toString <| abs <| (end.y - start.y) // 2
+    , Attr.cx <| toString <| start.x + ((end.x - start.x) // 2)
+    , Attr.cy <| toString <| start.y + ((end.y - start.y) // 2)
     , Attr.filter "url(#dropShadow)"
     ]
 
@@ -998,8 +998,7 @@ simpleLineAttrs : Shape -> List (Svg.Attribute Msg)
 simpleLineAttrs { start, end } =
     [ Attr.fill "none"
     , Attr.d <| linePath start end
-
-    --  , Attr.filter "url(#dropShadow)"
+      --  , Attr.filter "url(#dropShadow)"
     ]
 
 

--- a/src/Goat/View.elm
+++ b/src/Goat/View.elm
@@ -916,17 +916,7 @@ viewVertex vertexEvents x y =
 
 ellipseVertices : (Vertex -> ResizeDirection -> List (Svg.Attribute Msg)) -> StartPosition -> EndPosition -> List (Svg Msg)
 ellipseVertices toVertexEvents start end =
-    let
-        dX =
-            end.x - start.x
-
-        dY =
-            end.y - start.y
-
-        rectStart =
-            Position (start.x - dX) (end.y - 2 * dY)
-    in
-        shapeVertices toVertexEvents rectStart end
+    shapeVertices toVertexEvents start end
 
 
 viewTextArea : Int -> TextArea -> Svg Msg

--- a/tests/View/Annotation.elm
+++ b/tests/View/Annotation.elm
@@ -48,10 +48,10 @@ strokeSelectors strokeWidth dashArray strokeColor =
 
 ellipseSelector : Shape -> List Selector
 ellipseSelector shape =
-    [ attribute "rx" <| toString <| abs end.x - start.x
-    , attribute "ry" <| toString <| abs end.y - start.y
-    , attribute "cx" <| toString start.x
-    , attribute "cy" <| toString start.y
+    [ attribute "rx" <| toString <| abs <| (end.x - start.x) // 2
+    , attribute "ry" <| toString <| abs <| (end.y - start.y) // 2
+    , attribute "cx" <| toString <| start.x + ((end.x - start.x) // 2)
+    , attribute "cy" <| toString <| start.y + ((end.y - start.y) // 2)
     , attribute "filter" "url(#dropShadow)"
     ]
         ++ (uncurry strokeSelectors (toLineStyle shape.strokeStyle)) shape.strokeColor


### PR DESCRIPTION
No more center-drawn circles.

✓ Includes anchor points
✓ Includes resizing

Does _not_ do Shift-for-circle on resizing, but that is not a regression

The integer math makes the ellipses a little jittery. Greg, i'll probably leave it to you if you want to maybe constrain the radius to multiples of 0.5 instead of ints?

Demo movie https://www.dropbox.com/s/vs9kz5pnk4zld9p/goat%20circle%20resize.mov?dl=0