### PR TITLE
Add shortcut to do the elm-live stuff

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+elm-live src/Main.elm --output=elm.js --debug


### PR DESCRIPTION
my shell history isn't saved per-tab and I’m too lazy to find out why. this will save a tiny bit of time