### PR TITLE
New Line View

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 cache:
   directories:
-    - tests/elm-stuff/build-artifacts
     - sysconfcpus
 
 os:

--- a/src/Goat/Utils.elm
+++ b/src/Goat/Utils.elm
@@ -223,7 +223,7 @@ getFirstSpotlightIndex annotations =
         |> Maybe.withDefault 0
 
 
-shiftPosition : Int -> Int -> Mouse.Position -> Mouse.Position
+shiftPosition : number -> number -> { x : number, y : number } -> { x : number, y : number }
 shiftPosition dx dy pos =
     { pos | x = pos.x + dx, y = pos.y + dy }
 

--- a/src/Goat/View/DrawingArea/Annotation.elm
+++ b/src/Goat/View/DrawingArea/Annotation.elm
@@ -84,10 +84,10 @@ strokeAttrs strokeStyle strokeColor =
 
 
 simpleLineAttrs : Shape -> List (Svg.Attribute Msg)
-simpleLineAttrs { start, end, strokeColor } =
+simpleLineAttrs { start, end, strokeColor, strokeStyle } =
     [ Attr.stroke "none"
     , Attr.fill <| Color.Convert.colorToHex strokeColor
-    , Attr.d <| linePath start end
+    , Attr.d <| linePath (toStrokeWidth strokeStyle) start end
     , Attr.filter "url(#dropShadow)"
     ]
 

--- a/src/Goat/View/DrawingArea/Annotation.elm
+++ b/src/Goat/View/DrawingArea/Annotation.elm
@@ -84,11 +84,11 @@ strokeAttrs strokeStyle strokeColor =
 
 
 simpleLineAttrs : Shape -> List (Svg.Attribute Msg)
-simpleLineAttrs { start, end } =
-    [ Attr.fill "none"
+simpleLineAttrs { start, end, strokeColor } =
+    [ Attr.stroke "none"
+    , Attr.fill <| Color.Convert.colorToHex strokeColor
     , Attr.d <| linePath start end
-
-    --  , Attr.filter "url(#dropShadow)"
+    , Attr.filter "url(#dropShadow)"
     ]
 
 
@@ -132,7 +132,7 @@ lineAttributes lineType shape =
             strokeAttrs shape.strokeStyle shape.strokeColor ++ arrowAttributes shape
 
         StraightLine ->
-            simpleLineAttrs shape ++ strokeAttrs shape.strokeStyle shape.strokeColor
+            strokeAttrs shape.strokeStyle shape.strokeColor ++ simpleLineAttrs shape
 
 
 viewDrawing : Model -> AnnotationAttributes -> StartPosition -> Position -> Bool -> Svg Msg

--- a/src/Goat/View/Utils.elm
+++ b/src/Goat/View/Utils.elm
@@ -30,30 +30,62 @@ stopPropagation =
 
 toLineStyle : StrokeStyle -> ( String, String )
 toLineStyle strokeStyle =
+    let
+        strokeWidth =
+            toStrokeWidth strokeStyle
+    in
+        case strokeStyle of
+            SolidThin ->
+                toString strokeWidth => ""
+
+            SolidMedium ->
+                toString strokeWidth => ""
+
+            SolidThick ->
+                toString strokeWidth => ""
+
+            SolidVeryThick ->
+                toString strokeWidth => ""
+
+            DashedThin ->
+                toString strokeWidth => "10, 5"
+
+            DashedMedium ->
+                toString strokeWidth => "10, 5"
+
+            DashedThick ->
+                toString strokeWidth => "10, 5"
+
+            DashedVeryThick ->
+                toString strokeWidth => "10, 5"
+
+
+toStrokeWidth : StrokeStyle -> number
+toStrokeWidth strokeStyle =
     case strokeStyle of
         SolidThin ->
-            "2" => ""
+            2
 
         SolidMedium ->
-            "4" => ""
+            4
 
         SolidThick ->
-            "6" => ""
+            6
 
         SolidVeryThick ->
-            "8" => ""
+            8
 
         DashedThin ->
-            "2" => "10, 5"
+            2
 
         DashedMedium ->
-            "4" => "10, 5"
+            4
 
         DashedThick ->
-            "6" => "10, 5"
+            6
 
         DashedVeryThick ->
-            "8" => "10, 5"
+            8
 
 
 posToString : { x : number, y : number } -> String
@@ -61,8 +93,8 @@ posToString pos =
     toString pos.x ++ "," ++ toString pos.y
 
 
-linePath : StartPosition -> EndPosition -> String
-linePath start end =
+linePath : Float -> StartPosition -> EndPosition -> String
+linePath strokeWidth start end =
     let
         theta =
             (2 * pi)
@@ -81,13 +113,13 @@ linePath start end =
             { x = toFloat start.x, y = toFloat start.y }
 
         ccPt1 =
-            shiftPosition (5 * cos perpen) (5 * sin perpen) startFloat
+            shiftPosition ((strokeWidth / 2) * cos perpen) ((strokeWidth / 2) * sin perpen) startFloat
 
         ccPt2 =
             shiftPosition dx dy ccPt1
 
         ccPt3 =
-            shiftPosition (-10 * cos perpen) (-10 * sin perpen) ccPt2
+            shiftPosition (-strokeWidth * cos perpen) (-strokeWidth * sin perpen) ccPt2
 
         ccPt4 =
             shiftPosition -dx -dy ccPt3

--- a/src/Goat/View/Utils.elm
+++ b/src/Goat/View/Utils.elm
@@ -5,7 +5,7 @@ import Html exposing (Attribute)
 import Html.Events exposing (on)
 import Json.Decode as Json
 import Rocket exposing ((=>))
-import Goat.Utils exposing (arrowAngle)
+import Goat.Utils exposing (arrowAngle, shiftPosition)
 
 
 onMouseDown : Json.Decoder msg -> Attribute msg
@@ -56,9 +56,53 @@ toLineStyle strokeStyle =
             "8" => "10, 5"
 
 
+posToString : { x : number, y : number } -> String
+posToString pos =
+    toString pos.x ++ "," ++ toString pos.y
+
+
 linePath : StartPosition -> EndPosition -> String
 linePath start end =
-    "M" ++ toString start.x ++ "," ++ toString start.y ++ " l" ++ toString (end.x - start.x) ++ "," ++ toString (end.y - start.y)
+    let
+        theta =
+            (2 * pi)
+                - (arrowAngle start end)
+
+        perpen =
+            (pi / 2) - theta
+
+        dx =
+            toFloat (end.x - start.x)
+
+        dy =
+            toFloat (end.y - start.y)
+
+        startFloat =
+            { x = toFloat start.x, y = toFloat start.y }
+
+        ccPt1 =
+            shiftPosition (5 * cos perpen) (5 * sin perpen) startFloat
+
+        ccPt2 =
+            shiftPosition dx dy ccPt1
+
+        ccPt3 =
+            shiftPosition (-10 * cos perpen) (-10 * sin perpen) ccPt2
+
+        ccPt4 =
+            shiftPosition -dx -dy ccPt3
+    in
+        "M"
+            ++ posToString start
+            ++ " L"
+            ++ posToString ccPt1
+            ++ " L"
+            ++ posToString ccPt2
+            ++ " L"
+            ++ posToString ccPt3
+            ++ " L"
+            ++ posToString ccPt4
+            ++ "Z"
 
 
 directionToCursor : ResizeDirection -> String

--- a/tests/src/View/DrawingArea/Annotation.elm
+++ b/tests/src/View/DrawingArea/Annotation.elm
@@ -18,7 +18,7 @@ import Goat.Model
 import Goat.Utils exposing (arrowAngle)
 import Goat.View.DrawingArea.Annotation exposing (viewAnnotation)
 import Goat.View.DrawingArea exposing (viewImage, viewPixelatedImage)
-import Goat.View.Utils exposing (arrowPath, arrowHeadPath, linePath, toLineStyle, fontSizeToLineHeight)
+import Goat.View.Utils exposing (arrowPath, arrowHeadPath, linePath, toLineStyle, fontSizeToLineHeight, toStrokeWidth)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as HtmlSelector exposing (Selector, all, attribute, class, tag, text)
@@ -36,10 +36,10 @@ all =
 
 lineSelector : Shape -> List Selector
 lineSelector shape =
-    [ attribute "fill" "none"
-    , attribute "d" (linePath shape.start shape.end)
+    [ attribute "stroke" "none"
+    , attribute "fill" (Color.Convert.colorToHex shape.strokeColor)
+    , attribute "d" (linePath (toStrokeWidth shape.strokeStyle) shape.start shape.end)
     ]
-        ++ (uncurry strokeSelectors (toLineStyle shape.strokeStyle)) shape.strokeColor
 
 
 arrowSelector : Shape -> List Selector


### PR DESCRIPTION
The line annotation is now a rectangular path. This means the drop shadow works perfectly, but also that we use `fill` instead of `stroke`. This means we lose the ability to apply a `dash-array` property. I think we can bring that functionality back with a later PR for both arrows and lines.