### PR TITLE
Fix spotlight ordering regression

### DIFF
--- a/src/Goat/View/DrawingArea.elm
+++ b/src/Goat/View/DrawingArea.elm
@@ -5,7 +5,7 @@ import Goat.Flags exposing (Image)
 import Goat.Model exposing (..)
 import Goat.Update exposing (Msg(..), autoExpandConfig)
 import Goat.Utils exposing (getFirstSpotlightIndex, toDrawingPosition, toPosition)
-import Goat.View.DrawingArea.Annotation as Annotation
+import Goat.View.DrawingArea.Annotation as Annotation exposing (viewAnnotation)
 import Goat.View.DrawingArea.Definitions as Definitions
 import Goat.View.Utils exposing (..)
 import Html exposing (Attribute, Html, button, div, h2, h3, img, li, p, text, ul)

--- a/src/Goat/View/DrawingArea/Definitions.elm
+++ b/src/Goat/View/DrawingArea/Definitions.elm
@@ -13,13 +13,17 @@ import Svg.Attributes as Attr
 
 viewNonSpotlightAnnotations : AnnotationState -> Array Annotation -> List (Svg Msg)
 viewNonSpotlightAnnotations annotationState annotations =
-    annotations
-        |> Array.toList
-        |> List.indexedMap (Annotation.viewAnnotation annotationState)
-        |> List.concat
+    let
+        annotationsAndVertices =
+            annotations
+                |> Array.toList
+                |> List.indexedMap (Annotation.viewAnnotation annotationState)
+    in
+        List.map Tuple.first annotationsAndVertices
+            ++ List.filterMap Tuple.second annotationsAndVertices
 
 
-viewMaskCutOut : AnnotationState -> ( Int, ShapeType, Shape ) -> List (Svg Msg)
+viewMaskCutOut : AnnotationState -> ( Int, ShapeType, Shape ) -> Svg Msg
 viewMaskCutOut annotationState ( index, shapeType, shape ) =
     Annotation.viewShape (Annotation.annotationStateEvents index annotationState) shapeType (Just Color.black) shape
 
@@ -29,7 +33,6 @@ viewSpotlights annotationState annotations =
     annotations
         |> Array.toIndexedList
         |> List.filterMap (Maybe.map (viewMaskCutOut annotationState) << spotlightToMaskCutout)
-        |> List.concat
 
 
 viewPixelates : AnnotationState -> Array Annotation -> List (Svg Msg)

--- a/src/Goat/View/DrawingArea/Vertices.elm
+++ b/src/Goat/View/DrawingArea/Vertices.elm
@@ -24,7 +24,7 @@ viewVertex vertexEvents x y =
         []
 
 
-shapeVertices : (Vertex -> ResizeDirection -> List (Svg.Attribute Msg)) -> StartPosition -> EndPosition -> List (Svg Msg)
+shapeVertices : (Vertex -> ResizeDirection -> List (Svg.Attribute Msg)) -> StartPosition -> EndPosition -> Svg Msg
 shapeVertices toVertexEvents start end =
     let
         ( resizeDir1, resizeDir2, resizeDir3, resizeDir4 ) =
@@ -37,21 +37,23 @@ shapeVertices toVertexEvents start end =
             else
                 ( NESW, NWSE, NWSE, NESW )
     in
-        [ viewVertex (toVertexEvents Start resizeDir1) start.x start.y
-        , viewVertex (toVertexEvents StartPlusX resizeDir2) end.x start.y
-        , viewVertex (toVertexEvents StartPlusY resizeDir3) start.x end.y
-        , viewVertex (toVertexEvents End resizeDir4) end.x end.y
+        Svg.g []
+            [ viewVertex (toVertexEvents Start resizeDir1) start.x start.y
+            , viewVertex (toVertexEvents StartPlusX resizeDir2) end.x start.y
+            , viewVertex (toVertexEvents StartPlusY resizeDir3) start.x end.y
+            , viewVertex (toVertexEvents End resizeDir4) end.x end.y
+            ]
+
+
+lineVertices : (Vertex -> ResizeDirection -> List (Svg.Attribute Msg)) -> StartPosition -> EndPosition -> Svg Msg
+lineVertices toVertexEvents start end =
+    Svg.g []
+        [ viewVertex (toVertexEvents Start Move) start.x start.y
+        , viewVertex (toVertexEvents End Move) end.x end.y
         ]
 
 
-lineVertices : (Vertex -> ResizeDirection -> List (Svg.Attribute Msg)) -> StartPosition -> EndPosition -> List (Svg Msg)
-lineVertices toVertexEvents start end =
-    [ viewVertex (toVertexEvents Start Move) start.x start.y
-    , viewVertex (toVertexEvents End Move) end.x end.y
-    ]
-
-
-viewVertices : Vertices -> StartPosition -> EndPosition -> (Vertex -> ResizeDirection -> List (Svg.Attribute Msg)) -> SelectState -> List (Svg Msg)
+viewVertices : Vertices -> StartPosition -> EndPosition -> (Vertex -> ResizeDirection -> List (Svg.Attribute Msg)) -> SelectState -> Maybe (Svg Msg)
 viewVertices vertices start end toVertexEvents selectState =
     let
         toVertices =
@@ -63,6 +65,6 @@ viewVertices vertices start end toVertexEvents selectState =
                     lineVertices
     in
         if selectState == SelectedWithVertices then
-            toVertices toVertexEvents start end
+            Just (toVertices toVertexEvents start end)
         else
-            []
+            Nothing

--- a/tests/src/View/DrawingArea/Annotation.elm
+++ b/tests/src/View/DrawingArea/Annotation.elm
@@ -4,6 +4,7 @@ import Color exposing (Color)
 import Color.Convert
 import Expect exposing (Expectation)
 import Fixtures exposing (end, goat, model, start, aShape, aTextArea, testColor)
+import Html exposing (Html)
 import Goat.Flags exposing (Image)
 import Goat.Model
     exposing
@@ -15,6 +16,7 @@ import Goat.Model
         , ShapeType(..)
         , TextArea
         )
+import Goat.Update exposing (Msg)
 import Goat.Utils exposing (arrowAngle)
 import Goat.View.DrawingArea.Annotation exposing (viewAnnotation)
 import Goat.View.DrawingArea exposing (viewImage, viewPixelatedImage)
@@ -146,6 +148,15 @@ imageTests =
         ]
 
 
+viewFirstAnnotation : Annotation -> Html Msg
+viewFirstAnnotation annotation =
+    annotation
+        |> viewAnnotation ReadyToDraw 0
+        |> Tuple.first
+        |> List.singleton
+        |> svgDrawspace
+
+
 pixelatedImageTests : Test
 pixelatedImageTests =
     describe "viewPixelatedImage"
@@ -165,8 +176,7 @@ viewAnnotationTests =
             \() ->
                 aShape
                     |> Lines StraightLine
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.find [ tag "path" ]
                     |> Query.has (lineSelector aShape)
@@ -174,8 +184,7 @@ viewAnnotationTests =
             \() ->
                 aShape
                     |> Lines Arrow
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.findAll [ tag "path" ]
                     |> Query.first
@@ -184,8 +193,7 @@ viewAnnotationTests =
             \() ->
                 aShape
                     |> Lines Arrow
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.findAll [ tag "path" ]
                     |> Query.index 1
@@ -194,8 +202,7 @@ viewAnnotationTests =
             \() ->
                 aShape
                     |> Shapes Rect (Just testColor)
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.find [ tag "rect" ]
                     |> Query.has (rectSelector aShape)
@@ -203,8 +210,7 @@ viewAnnotationTests =
             \() ->
                 aShape
                     |> Shapes RoundedRect (Just testColor)
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.find [ tag "rect" ]
                     |> Query.has (roundedRectSelector aShape)
@@ -212,8 +218,7 @@ viewAnnotationTests =
             \() ->
                 aShape
                     |> Shapes Ellipse (Just testColor)
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.find [ tag "ellipse" ]
                     |> Query.has (ellipseSelector aShape)
@@ -221,8 +226,7 @@ viewAnnotationTests =
             \() ->
                 aTextArea
                     |> TextBox
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.find [ tag "text" ]
                     |> Query.has (svgTextSelector aTextArea)
@@ -230,8 +234,7 @@ viewAnnotationTests =
             \() ->
                 aTextArea
                     |> TextBox
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.findAll [ tag "tspan" ]
                     |> Query.each
@@ -242,8 +245,7 @@ viewAnnotationTests =
             \() ->
                 aShape
                     |> Spotlight Rect
-                    |> viewAnnotation ReadyToDraw 0
-                    |> svgDrawspace
+                    |> viewFirstAnnotation
                     |> Query.fromHtml
                     |> Query.find [ tag "rect" ]
                     |> Query.has (rectSelector aShape)


### PR DESCRIPTION
After the addition of the path-based arrow #68 , the insertion point of the Spotlight gray backdrop would be incorrect when drawings contained the new arrow. The gray backdrop could also happen at times when vertices were shown in the drawing.

## Cause
`viewAnnotation` was returning a list of Svgs. This list included the annotation itself, and any vertices when it is selected. These lists of Svgs were concatenated together. The insertion point for the gray backdrop was based on the index of the first spotlight annotation in the internal array representation. I was using this index to insert the gray backdrop, but sometimes this index would be incorrect: some annotations now had two svgs! This included the svg arrow, with its arrow head and tail.

## Solution

Refactor `viewAnnotation` to be more explicit. Only return a single Svg (group with the `g` tag only when necessary). Return a second argument for vertices: (if there are any). Vertices should always come at the end of the svg list as well, since they should appear above all annotations/masks.
Now, the svg drawing area has a list of svgs (sometimes `g` tags) for annotations, and at the end of the list: perhaps some vertices.